### PR TITLE
Forward labels and annotations from schedule cr to engines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build:
 	@echo "------------------"
 	@echo "--> Build Chaos Scheduler"
 	@echo "------------------"
-	@go build -o ${GOPATH}/src/github.com/litmuschaos/chaos-scheduler/build/_output/bin/chaos-scheduler -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} github.com/litmuschaos/chaos-scheduler/cmd/manager 
+	@go build -o build/_output/bin/chaos-scheduler -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} github.com/litmuschaos/chaos-scheduler/cmd/manager
 
 .PHONY: codegen
 codegen:

--- a/pkg/controller/chaosscheduler/createEngineForNowAndOnce.go
+++ b/pkg/controller/chaosscheduler/createEngineForNowAndOnce.go
@@ -34,6 +34,8 @@ func (schedulerReconcile *reconcileScheduler) createForNowAndOnce(cs *chaosTypes
 		engine = getEngineFromTemplate(cs)
 		engine.Name = cs.Instance.Name
 		engine.Namespace = cs.Instance.Namespace
+		engine.Labels = cs.Instance.Labels
+		engine.Annotations = cs.Instance.Annotations
 
 		err = schedulerReconcile.r.client.Create(context.TODO(), engine)
 		if err != nil {

--- a/pkg/controller/chaosscheduler/createEngineForRepeat.go
+++ b/pkg/controller/chaosscheduler/createEngineForRepeat.go
@@ -87,6 +87,8 @@ func (schedulerReconcile *reconcileScheduler) createNewEngine(cs *chaosTypes.Sch
 	engineReq := getEngineFromTemplate(cs)
 	engineReq.Name = fmt.Sprintf("%s-%d", cs.Instance.Name, getTimeHash(scheduledTime))
 	engineReq.Namespace = cs.Instance.Namespace
+	engineReq.Labels = cs.Instance.Labels
+	engineReq.Annotations = cs.Instance.Annotations
 
 	errCreate := schedulerReconcile.r.client.Create(context.TODO(), engineReq)
 	if errCreate != nil {


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

This PR forwards the labels and annotations from the chaos schedule to the chaos engines created by the schedule.